### PR TITLE
Lispress no hash space paren

### DIFF
--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -142,20 +142,19 @@ def _render_value_expressions(sexp: Sexp) -> Sexp:
     This ensures that values are always atomically rendered on the same line,
     and also allows us to render "#(" without a space between them.
     """
-    if isinstance(sexp, str) or len(sexp) < 2:
+    if isinstance(sexp, str):
         return sexp
-    elif VALUE_CHAR not in sexp:
-        return [_render_value_expressions(s) for s in sexp]
     else:
         result = []
         i = 0
         while i < len(sexp):
-            token = sexp[i]
-            if token == VALUE_CHAR and i + 1 < len(sexp):
+            s = sexp[i]
+            if s == VALUE_CHAR and i + 1 < len(sexp):
+                # merge "#" and the following (rendered) subexpression
                 result.append(VALUE_CHAR + render_compact(sexp[i + 1]))
                 i += 2
             else:
-                result.append(token)
+                result.append(_render_value_expressions(s))
                 i += 1
         return result
 

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -145,7 +145,7 @@ def _render_value_expressions(sexp: Sexp) -> Sexp:
     if isinstance(sexp, str):
         return sexp
     else:
-        result = []
+        result: List[Lispress] = []
         i = 0
         while i < len(sexp):
             s = sexp[i]

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -91,6 +91,21 @@ surface_strings = [
     '(#(String "i got quotes\\""))',
     # tests that empty plans are handled correctly
     "()",
+    # tests that no whitespace is inserted between "#" and "("
+    """
+(Yield
+  :output (:start
+    (FindNumNextEvent
+      :constraint (Constraint[Event]
+        :attendees (AttendeeListHasRecipient
+          :recipient (FindManager
+            :recipient (Execute
+              :intension (refer
+                (extensionConstraint
+                  (RecipientWithNameLike
+                    :constraint (Constraint[Recipient])
+                    :name #(PersonName "Tom"))))))))
+      :number #(Number 1))))""",
 ]
 
 

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -91,7 +91,8 @@ surface_strings = [
     '(#(String "i got quotes\\""))',
     # tests that empty plans are handled correctly
     "()",
-    # tests that no whitespace is inserted between "#" and "("
+    # regression test that no whitespace is inserted between "#" and "(".
+    # `#(PersonName "Tom")` was being rendered with whitespace.
     """
 (Yield
   :output (:start
@@ -131,6 +132,7 @@ def test_surface_to_program_round_trips():
         sexp = parse_lispress(surface_string)
         program, _ = lispress_to_program(sexp, 0)
         round_tripped_sexp = program_to_lispress(program)
+        assert round_tripped_sexp == sexp
         round_tripped_surface_string = render_pretty(round_tripped_sexp, max_width=60)
         assert round_tripped_surface_string == surface_string
 


### PR DESCRIPTION
Fixes a bug where whitespace was sometimes inserted between `#` and `(` when rendering `Lispress`.

This will not affect evaluation/accuracy because gold and predicted programs are parsed and re-rendered before testing for equality.