### PR TITLE
Clarify the evaluation discrepancies between the TACL paper and the leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ You can skip these two packages if you don't need to train or run the models.
 ## SMCalFlow Experiments
 Follow the steps below to reproduce the results reported in the paper (Table 2).
 
+**NOTE: We highly recommend following [the instructions](https://worksheets.codalab.org/worksheets/0xfc168b6317924c8a85df9ecd39bc52b2) for 
+[the leaderboard](https://microsoft.github.io/task_oriented_dialogue_as_dataflow_synthesis/) to report your results for consistency.**
+If you use your own evaluation script, please pay attention to the notes in Step 2 and Step 7.
+
 1. Download the SMCalFlow dataset on [this page](https://microsoft.github.io/task_oriented_dialogue_as_dataflow_synthesis/).
 
 2. Compute data statistics:
@@ -237,6 +241,13 @@ with the final model you get from the previous step.
         --datum_ids_json ${dataflow_dialogues_stats_dir}/valid.revise_turn_ids.jsonl \
         --scores_json ${evaluation_outdir}/valid.revise_turns.scores.json
     ```
+   * **NOTE**: The numbers reported using the scripts above should match those reported in Table 2 
+    in [the paper](https://www.mitpressjournals.org/doi/full/10.1162/tacl_a_00333).
+    [The leaderboard](https://microsoft.github.io/task_oriented_dialogue_as_dataflow_synthesis/) has used a slightly
+    different evaluation script that canonicalizes both the gold and predicted programs, and thus, the accuracy would be
+    slightly higher (e.g., 0.665 vs. 0.668 on the test set). To obtain the leaderboard results, please add 
+    `--use_leaderboard_metric` when running `python -m dataflow.onmt_helpers.create_onmt_prediction_report` to create
+    the report. 
    
 8. Calculate the statistical significance for two different experiments.
     ```bash

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -46,6 +46,22 @@ VALUE_CHAR = "#"
 Lispress = Sexp
 
 
+def try_round_trip(lispress_str: str) -> str:
+    """
+    If `lispress_str` is valid lispress, round-trips it to and from `Program`.
+    This puts named arguments in alphabetical order.
+    If it is not valid, returns the original string unmodified.
+    """
+    try:
+        # round-trip to canonicalize
+        lispress = parse_lispress(lispress_str)
+        program, _ = lispress_to_program(lispress, 0)
+        round_tripped = program_to_lispress(program)
+        return render_compact(round_tripped)
+    except Exception:  # pylint: disable=W0703
+        return lispress_str
+
+
 def program_to_lispress(program: Program) -> Lispress:
     """ Converts a Program to Lispress. """
     unsugared = _program_to_unsugared_lispress(program)

--- a/src/dataflow/leaderboard/evaluate.py
+++ b/src/dataflow/leaderboard/evaluate.py
@@ -11,35 +11,14 @@ from typing import Iterable, List, Optional, Set, Tuple
 
 from dataflow.core.dialogue import TurnId
 from dataflow.core.io import load_jsonl_file
-from dataflow.core.lispress import (
-    lispress_to_program,
-    parse_lispress,
-    program_to_lispress,
-    render_compact,
-)
+from dataflow.core.lispress import try_round_trip
 from dataflow.core.turn_prediction import TurnAnswer, TurnPrediction, missing_prediction
-
-
-def _try_round_trip(lispress_str: str) -> str:
-    """
-    If `lispress_str` is valid lispress, round-trips it to and from `Program`.
-    This puts named arguments in alphabetical order.
-    If it is not valid, returns the original string unmodified.
-    """
-    try:
-        # round-trip to canonicalize
-        lispress = parse_lispress(lispress_str)
-        program, _ = lispress_to_program(lispress, 0)
-        round_tripped = program_to_lispress(program)
-        return render_compact(round_tripped)
-    except Exception:  # pylint: disable=W0703
-        return lispress_str
 
 
 def evaluate_prediction_exact_match(pred: TurnPrediction, gold: TurnAnswer) -> bool:
     assert pred.datum_id == gold.datum_id, f"mismatched data: {pred}, {gold}"
-    pred_lispress = _try_round_trip(pred.lispress)
-    gold_lispress = _try_round_trip(gold.lispress)
+    pred_lispress = try_round_trip(pred.lispress)
+    gold_lispress = try_round_trip(gold.lispress)
     return (
         pred_lispress == gold_lispress
         and gold.program_execution_oracle.refer_are_correct

--- a/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
+++ b/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
@@ -158,7 +158,8 @@ def create_onmt_prediction_report(
             "isCorrectLeaderboard",
             "gold",
             "prediction",
-            "goldCanonical" "predictionCanonical",
+            "goldCanonical",
+            "predictionCanonical",
         ],
     )
     return predictions_jsonl

--- a/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
+++ b/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
@@ -158,8 +158,7 @@ def create_onmt_prediction_report(
             "isCorrectLeaderboard",
             "gold",
             "prediction",
-            "goldCanonical"
-            "predictionCanonical"
+            "goldCanonical" "predictionCanonical",
         ],
     )
     return predictions_jsonl

--- a/src/dataflow/onmt_helpers/evaluate_onmt_predictions.py
+++ b/src/dataflow/onmt_helpers/evaluate_onmt_predictions.py
@@ -90,7 +90,9 @@ def evaluate_dialogue(turns: List[Tuple[int, bool]]) -> EvaluationScores:
     )
 
 
-def evaluate_dataset(prediction_report_df: pd.DataFrame, use_leaderboard_metric: bool) -> EvaluationScores:
+def evaluate_dataset(
+    prediction_report_df: pd.DataFrame, use_leaderboard_metric: bool
+) -> EvaluationScores:
     # pylint: disable=singleton-comparison
     dataset_scores = EvaluationScores()
     if use_leaderboard_metric:
@@ -109,7 +111,8 @@ def evaluate_dataset(prediction_report_df: pd.DataFrame, use_leaderboard_metric:
 
 
 def main(
-    prediction_report_tsv: str, datum_ids_jsonl: Optional[str],
+    prediction_report_tsv: str,
+    datum_ids_jsonl: Optional[str],
     use_leaderboard_metric: bool,
     scores_json: str,
 ) -> None:
@@ -148,8 +151,10 @@ def add_arguments(argument_parser: argparse.ArgumentParser) -> None:
         "--datum_ids_jsonl", default=None, help="if set, only evaluate on these turns",
     )
     argument_parser.add_argument(
-        "--use_leaderboard_metric", default=False, action="store_true",
-        help="if set, use the isCorrectLeaderboard field instead of isCorrect field in the prediction report"
+        "--use_leaderboard_metric",
+        default=False,
+        action="store_true",
+        help="if set, use the isCorrectLeaderboard field instead of isCorrect field in the prediction report",
     )
     argument_parser.add_argument("--scores_json", help="output scores json file")
 
@@ -163,11 +168,13 @@ if __name__ == "__main__":
 
     print("Semantic Machines\N{TRADE MARK SIGN} software.")
     if not args.use_leaderboard_metric:
-        print("""
+        print(
+            """
         WARNING: The flag --use_leaderboard_metric is not set. The reported results will be consistent with the numbers
         reported in the TACL2020 paper. To report on the leaderboard evaluation metric, please use
         --use_leaderboard_metric, which canonicalizes the labels and predictions.
-        """)
+        """
+        )
     main(
         prediction_report_tsv=args.prediction_report_tsv,
         datum_ids_jsonl=args.datum_ids_jsonl,

--- a/src/dataflow/onmt_helpers/evaluate_onmt_predictions.py
+++ b/src/dataflow/onmt_helpers/evaluate_onmt_predictions.py
@@ -169,11 +169,10 @@ if __name__ == "__main__":
     print("Semantic Machines\N{TRADE MARK SIGN} software.")
     if not args.use_leaderboard_metric:
         print(
-            """
-        WARNING: The flag --use_leaderboard_metric is not set. The reported results will be consistent with the numbers
-        reported in the TACL2020 paper. To report on the leaderboard evaluation metric, please use
-        --use_leaderboard_metric, which canonicalizes the labels and predictions.
-        """
+            "WARNING: The flag --use_leaderboard_metric is not set."
+            " The reported results will be consistent with the numbers"
+            " reported in the TACL2020 paper. To report on the leaderboard evaluation metric, please use"
+            " --use_leaderboard_metric, which canonicalizes the labels and predictions."
         )
     main(
         prediction_report_tsv=args.prediction_report_tsv,


### PR DESCRIPTION
The README in the github can only compute results reported in the TACL paper, but the leaderboard has used a slightly different evaluation script.
This PR clarifies this difference. In particular, I added a flag `--use_leaderboard_metrics` to the `create_prediction_report.py` so that people can choose to use the leaderboard metric. Also, by default, this script would print a warning if `--use_leaderboard_metrics` is not set.

I also update the README to highlight the potential evaluation issue.