### PR TITLE
fix the leaderboard metric in onmt_helpers

### DIFF
--- a/src/dataflow/core/linearize.py
+++ b/src/dataflow/core/linearize.py
@@ -18,6 +18,17 @@ from dataflow.core.program_utils import Idx, OpType
 from dataflow.core.sexp import Sexp
 
 
+def to_canonical_form(tokenized_lispress: str) -> str:
+    """Returns canonical form of a tokenized lispress.
+
+    The canonical form is un-tokenized and compact; it also sorts named arguments in alphabetical order.
+    """
+    lispress = seq_to_lispress(tokenized_lispress.split(" "))
+    program, _ = lispress_to_program(lispress, 0)
+    round_tripped = program_to_lispress(program)
+    return round_tripped
+
+
 def seq_to_program(seq: List[str], idx: Idx) -> Tuple[Program, Idx]:
     lispress = seq_to_lispress(seq)
     return lispress_to_program(lispress, idx)

--- a/src/dataflow/core/linearize.py
+++ b/src/dataflow/core/linearize.py
@@ -12,6 +12,7 @@ from dataflow.core.lispress import (
     Lispress,
     lispress_to_program,
     program_to_lispress,
+    render_compact,
 )
 from dataflow.core.program import Program
 from dataflow.core.program_utils import Idx, OpType
@@ -26,7 +27,7 @@ def to_canonical_form(tokenized_lispress: str) -> str:
     lispress = seq_to_lispress(tokenized_lispress.split(" "))
     program, _ = lispress_to_program(lispress, 0)
     round_tripped = program_to_lispress(program)
-    return round_tripped
+    return render_compact(round_tripped)
 
 
 def seq_to_program(seq: List[str], idx: Idx) -> Tuple[Program, Idx]:

--- a/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
+++ b/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
@@ -27,7 +27,7 @@ from dataflow.core.io import (
     save_jsonl_file,
 )
 from dataflow.core.linearize import seq_to_lispress, to_canonical_form
-from dataflow.core.lispress import render_compact, try_round_trip, lispress_to_program, program_to_lispress
+from dataflow.core.lispress import render_compact
 from dataflow.core.prediction_report import (
     PredictionReportDatum,
     save_prediction_report_tsv,

--- a/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
+++ b/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
@@ -53,10 +53,6 @@ class OnmtPredictionReportDatum(PredictionReportDatum):
 
     @property
     def gold_canonical(self) -> str:
-        """Returns canonical form of the gold lispress.
-
-        The canonical form is un-tokenized, compact, and sort named arguments in alphabetical order.
-        """
         return to_canonical_form(self.gold)
 
     @property

--- a/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
+++ b/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
@@ -26,8 +26,8 @@ from dataflow.core.io import (
     load_jsonl_file_and_build_lookup,
     save_jsonl_file,
 )
-from dataflow.core.linearize import seq_to_lispress
-from dataflow.core.lispress import render_compact, try_round_trip
+from dataflow.core.linearize import seq_to_lispress, to_canonical_form
+from dataflow.core.lispress import render_compact, try_round_trip, lispress_to_program, program_to_lispress
 from dataflow.core.prediction_report import (
     PredictionReportDatum,
     save_prediction_report_tsv,
@@ -45,17 +45,26 @@ _PARSE_ERROR_LISPRESS = '(parseError #(InvalidLispress "")'
 class OnmtPredictionReportDatum(PredictionReportDatum):
     datum_id: TurnId
     source: str
+    # The tokenized gold lispress.
     gold: str
+    # The tokenized predicted lispress.
     prediction: str
     program_execution_oracle: ProgramExecutionOracle
 
     @property
     def gold_canonical(self) -> str:
-        return try_round_trip(self.gold)
+        """Returns canonical form of the gold lispress.
+
+        The canonical form is un-tokenized, compact, and sort named arguments in alphabetical order.
+        """
+        return to_canonical_form(self.gold)
 
     @property
     def prediction_canonical(self) -> str:
-        return try_round_trip(self.prediction)
+        try:
+            return to_canonical_form(self.prediction)
+        except Exception:  # pylint: disable=W0703
+            return _PARSE_ERROR_LISPRESS
 
     @property
     def is_correct(self) -> bool:


### PR DESCRIPTION
This PR does not fix the leaderboard.
It only fixes the way I use `try_round_trip` in `onmt_helpers.create_onmt_prediction_report`. See inline comments.