### PR TITLE
parse and render top-level values without an extra set of parens

### DIFF
--- a/src/dataflow/analysis/calculate_statistical_significance.py
+++ b/src/dataflow/analysis/calculate_statistical_significance.py
@@ -92,7 +92,7 @@ def run_paired_permutation_test(
     xs: List[int],
     ys: List[int],
     samples: int = 10000,
-    statistic: Callable[[List[int]], float] = np.mean,
+    statistic: Callable[[List[int]], float] = np.mean,  # type: ignore
 ) -> float:
     """Runs the two-sample permutation test to check whether the paired data xs and ys are from the same distribution (null hypothesis).
 

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -175,11 +175,11 @@ def _render_value_expressions(sexp: Sexp) -> Sexp:
         # special-case top-level values because we can't strip out the last level
         # of parens in the Sexp:
         if (
-                isinstance(result, list)
-                # value has been turned into a single str already here by _render_value_expressions
-                and len(result) == 1
-                and isinstance(result[0], str)
-                and result[0].startswith(VALUE_CHAR)
+            isinstance(result, list)
+            # value has been turned into a single str already here by _render_value_expressions
+            and len(result) == 1
+            and isinstance(result[0], str)
+            and result[0].startswith(VALUE_CHAR)
         ):
             return result[0]
 

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -172,6 +172,17 @@ def _render_value_expressions(sexp: Sexp) -> Sexp:
             else:
                 result.append(_render_value_expressions(s))
                 i += 1
+        # special-case top-level values because we can't strip out the last level
+        # of parens in the Sexp:
+        if (
+                isinstance(result, list)
+                # value has been turned into a single str already here by _render_value_expressions
+                and len(result) == 1
+                and isinstance(result[0], str)
+                and result[0].startswith(VALUE_CHAR)
+        ):
+            return result[0]
+
         return result
 
 

--- a/src/dataflow/core/sexp.py
+++ b/src/dataflow/core/sexp.py
@@ -104,11 +104,7 @@ def parse_sexp(sexp_string: str, clean_singletons=False) -> Sexp:
 
     # special-case top-level values because they need an extra level
     # of parens in the Sexp:
-    if (
-        isinstance(result, list)
-        and len(result) >= 1
-        and result[0] == "#"
-    ):
+    if isinstance(result, list) and len(result) >= 1 and result[0] == "#":
         return [result]
     if clean_singletons and len(sexp_tmp) == 1:
         return sexp_tmp[0]

--- a/src/dataflow/core/sexp.py
+++ b/src/dataflow/core/sexp.py
@@ -50,7 +50,6 @@ def parse_sexp(sexp_string: str, clean_singletons=False) -> Sexp:
         return []
     if sexp_string[-1] == ";":
         sexp_string = sexp_string[:-1]
-
     # find and group top-level parentheses (that are not inside quoted strings)
     num_open_brackets = 0
     open_bracket_idxs = []
@@ -103,9 +102,16 @@ def parse_sexp(sexp_string: str, clean_singletons=False) -> Sexp:
     else:
         sexp_tmp = result
 
+    # special-case top-level values because they need an extra level
+    # of parens in the Sexp:
+    if (
+        isinstance(result, list)
+        and len(result) >= 1
+        and result[0] == "#"
+    ):
+        return [result]
     if clean_singletons and len(sexp_tmp) == 1:
         return sexp_tmp[0]
-
     return sexp_tmp
 
 

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -143,7 +143,7 @@ def test_program_to_lispress_with_quotes_inside_string():
     v, _ = mk_value_op(value='i got quotes"', schema="String", idx=0)
     program = Program(expressions=[v])
     rendered_lispress = render_pretty(program_to_lispress(program))
-    assert rendered_lispress == '(#(String "i got quotes\\""))'
+    assert rendered_lispress == '#(String "i got quotes\\"")'
     round_tripped, _ = lispress_to_program(parse_lispress(rendered_lispress), 0)
     assert round_tripped == program
 
@@ -151,4 +151,4 @@ def test_program_to_lispress_with_quotes_inside_string():
 def test_bare_values():
     surface_string = "0"
     round_tripped = try_round_trip(surface_string)
-    assert round_tripped == "(#(Number 0))"
+    assert round_tripped == "#(Number 0)"

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -88,8 +88,8 @@ surface_strings = [
             :subject (?= #(String "dinner at foo"))))))))""",
     # tests that whitespace is preserved inside a quoted string,
     # as opposed to tokenized and then joined with a single space.
-    '(#(String "multi\\tword  quoted\\nstring"))',
-    '(#(String "i got quotes\\""))',
+    '#(String "multi\\tword  quoted\\nstring")',
+    '#(String "i got quotes\\"")',
     # tests that empty plans are handled correctly
     "()",
     # regression test that no whitespace is inserted between "#" and "(".
@@ -144,11 +144,11 @@ def test_program_to_lispress_with_quotes_inside_string():
     program = Program(expressions=[v])
     rendered_lispress = render_pretty(program_to_lispress(program))
     assert rendered_lispress == '#(String "i got quotes\\"")'
-    round_tripped, _ = lispress_to_program(parse_lispress(rendered_lispress), 0)
+    sexp = parse_lispress(rendered_lispress)
+    round_tripped, _ = lispress_to_program(sexp, 0)
     assert round_tripped == program
 
 
 def test_bare_values():
-    surface_string = "0"
-    round_tripped = try_round_trip(surface_string)
-    assert round_tripped == "#(Number 0)"
+    assert try_round_trip("0") == "#(Number 0)"
+    assert try_round_trip("#(Number 0)") == "#(Number 0)"


### PR DESCRIPTION
Our released data does not have any top-level values, so this will not affect anything official.
See updated unit tests for example usage.