### PR TITLE
Normalize numbers in try_round_trip

### DIFF
--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -49,7 +49,8 @@ Lispress = Sexp
 def try_round_trip(lispress_str: str) -> str:
     """
     If `lispress_str` is valid lispress, round-trips it to and from `Program`.
-    This puts named arguments in alphabetical order.
+    This puts named arguments in alphabetical order and normalizes numbers
+    so they all have exactly one decimal place.
     If it is not valid, returns the original string unmodified.
     """
     try:
@@ -57,7 +58,18 @@ def try_round_trip(lispress_str: str) -> str:
         lispress = parse_lispress(lispress_str)
         program, _ = lispress_to_program(lispress, 0)
         round_tripped = program_to_lispress(program)
-        return render_compact(round_tripped)
+
+        def normalizeNumbers(exp: Lispress) -> "Lispress":
+            if isinstance(exp, str):
+                try:
+                    num = float(exp)
+                    return f"{num:.1f}"
+                except ValueError:
+                    return exp
+            else:
+                return [normalizeNumbers(e) for e in exp]
+
+        return render_compact(normalizeNumbers(round_tripped))
     except Exception:  # pylint: disable=W0703
         return lispress_str
 

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -59,7 +59,7 @@ def try_round_trip(lispress_str: str) -> str:
         program, _ = lispress_to_program(lispress, 0)
         round_tripped = program_to_lispress(program)
 
-        def normalizeNumbers(exp: Lispress) -> "Lispress":
+        def normalize_numbers(exp: Lispress) -> "Lispress":
             if isinstance(exp, str):
                 try:
                     num = float(exp)
@@ -67,9 +67,9 @@ def try_round_trip(lispress_str: str) -> str:
                 except ValueError:
                     return exp
             else:
-                return [normalizeNumbers(e) for e in exp]
+                return [normalize_numbers(e) for e in exp]
 
-        return render_compact(normalizeNumbers(round_tripped))
+        return render_compact(normalize_numbers(round_tripped))
     except Exception:  # pylint: disable=W0703
         return lispress_str
 

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -150,5 +150,5 @@ def test_program_to_lispress_with_quotes_inside_string():
 
 
 def test_bare_values():
-    assert try_round_trip("0") == "#(Number 0)"
-    assert try_round_trip("#(Number 0)") == "#(Number 0)"
+    assert try_round_trip("0") == "#(Number 0.0)"
+    assert try_round_trip("#(Number 0)") == "#(Number 0.0)"


### PR DESCRIPTION
Evaluation is currently sensitive to different number representation, so e.g. `#(Number 0) != #(Number 0.0)`. This change normalizes to the latter in all cases. 