### PR TITLE
Handle incoming special meta parsing (`^`), and clean up reader macro (`#`) handling as well

### DIFF
--- a/src/dataflow/core/sexp.py
+++ b/src/dataflow/core/sexp.py
@@ -47,7 +47,8 @@ def _split_respecting_quotes(s: str) -> List[str]:
 def parse_sexp(s: str) -> Sexp:
     offset = 0
 
-    def isEOI():
+    # eoi = end of input
+    def is_eoi():
         nonlocal offset
         return offset == len(s)
 
@@ -55,28 +56,28 @@ def parse_sexp(s: str) -> Sexp:
         nonlocal offset
         return s[offset]
 
-    def nextChar():
+    def next_char():
         # pylint: disable=used-before-assignment
         nonlocal offset
         cn = s[offset]
         offset += 1
         return cn
 
-    def skipWhitespace():
-        while (not isEOI()) and peek().isspace():
-            nextChar()
+    def skip_whitespace():
+        while (not is_eoi()) and peek().isspace():
+            next_char()
 
-    def skipThenPeek():
-        skipWhitespace()
+    def skip_then_peek():
+        skip_whitespace()
         return peek()
 
     def read() -> Sexp:
-        skipWhitespace()
-        c = nextChar()
+        skip_whitespace()
+        c = next_char()
         if c == LEFT_PAREN:
-            return readList()
+            return read_list()
         elif c == DOUBLE_QUOTE:
-            return readString()
+            return read_string()
         elif c == META:
             meta = read()
             expr = read()
@@ -84,48 +85,50 @@ def parse_sexp(s: str) -> Sexp:
         elif c == READER:
             return [READER, read()]
         else:
-            outInner = ""
+            out_inner = ""
             if c != "\\":
-                outInner += c
+                out_inner += c
 
             # TODO: is there a better loop idiom here?
-            if not isEOI():
-                nextC = peek()
+            if not is_eoi():
+                next_c = peek()
                 escaped = c == "\\"
-                while (not isEOI()) and (escaped or not _isBeginningControlChar(nextC)):
-                    if (not escaped) and nextC == "\\":
-                        nextChar()
+                while (not is_eoi()) and (
+                    escaped or not _is_beginning_control_char(next_c)
+                ):
+                    if (not escaped) and next_c == "\\":
+                        next_char()
                         escaped = True
                     else:
-                        outInner += nextChar()
+                        out_inner += next_char()
                         escaped = False
-                    if not isEOI():
-                        nextC = peek()
-            return outInner
+                    if not is_eoi():
+                        next_c = peek()
+            return out_inner
 
-    def readList():
-        outList = []
-        while skipThenPeek() != RIGHT_PAREN:
-            outList.append(read())
-        nextChar()
-        return outList
+    def read_list():
+        out_list = []
+        while skip_then_peek() != RIGHT_PAREN:
+            out_list.append(read())
+        next_char()
+        return out_list
 
-    def readString():
-        outStr = ""
+    def read_string():
+        out_str = ""
         while peek() != '"':
-            cString = nextChar()
-            outStr += cString
-            if cString == "\\":
-                outStr += nextChar()
-        nextChar()
-        return f'"{outStr}"'
+            c_string = next_char()
+            out_str += c_string
+            if c_string == "\\":
+                out_str += next_char()
+        next_char()
+        return f'"{out_str}"'
 
     out = read()
-    skipWhitespace()
+    skip_whitespace()
     return out
 
 
-def _isBeginningControlChar(nextC):
+def _is_beginning_control_char(nextC):
     return (
         nextC.isspace()
         or nextC == LEFT_PAREN

--- a/tests/test_dataflow/core/test_linearize.py
+++ b/tests/test_dataflow/core/test_linearize.py
@@ -1,6 +1,7 @@
 #  Copyright (c) Microsoft Corporation.
 #  Licensed under the MIT license.
 import json
+from typing import List
 
 from dataflow.core.linearize import (
     program_to_seq,
@@ -12,7 +13,7 @@ from dataflow.core.linearize import (
 )
 from dataflow.core.lispress import unnest_line
 from dataflow.core.program import Expression, Program, ValueOp
-from dataflow.core.sexp import flatten
+from dataflow.core.sexp import Sexp
 
 
 def test_plan_to_seq_strict():
@@ -49,6 +50,13 @@ def test_plan_to_seq_strict():
         "} } "
         ") )"
     )
+
+    def flatten(form: Sexp) -> List[str]:
+        return (
+            [form]
+            if not isinstance(form, list)
+            else [s for subexp in form for s in flatten(subexp)]
+        )
 
     linearized_plan_tokens = program_to_seq(program=original_program)
     assert all(" " not in tok for tok in flatten(linearized_plan_tokens))

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -7,6 +7,7 @@ from dataflow.core.lispress import (
 )
 from dataflow.core.program import Program
 from dataflow.core.program_utils import mk_value_op
+from dataflow.core.sexp import parse_sexp, sexp_to_str
 
 surface_strings = [
     """
@@ -152,3 +153,13 @@ def test_program_to_lispress_with_quotes_inside_string():
 def test_bare_values():
     assert try_round_trip("0") == "#(Number 0.0)"
     assert try_round_trip("#(Number 0)") == "#(Number 0.0)"
+
+
+def test_meta():
+    lispress = parse_sexp("^Number 1")
+    roundtrip = sexp_to_str(lispress)
+    assert roundtrip == "^Number 1"
+
+
+def test_simple():
+    assert try_round_trip('(+ (a) #(String "b")') == '(+ (a) #(String "b")'


### PR DESCRIPTION
Gets ready for the incoming Lispress with type ascriptions. I didn't understand the existing SExpression parser, so I ported The Scala version. Along the way, I found some conversions that I didn't quite understand but turn out to be unnecessary, at least as far as the tests are concerned. I would definitely appreciate some careful eyes since I'm not sure how extensive the test coverage is.