### PR TITLE
strip copy strings in eval

### DIFF
--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -69,7 +69,16 @@ def try_round_trip(lispress_str: str) -> str:
             else:
                 return [normalize_numbers(e) for e in exp]
 
-        return render_compact(normalize_numbers(round_tripped))
+        def strip_copy_strings(exp: Lispress) -> "Lispress":
+            if isinstance(exp, str):
+                if len(exp) > 2 and exp[0] == "\"" and exp[-1] == "\"":
+                    return "\"" + exp[1:-1].strip() + "\""
+                else:
+                    return exp
+            else:
+                return [strip_copy_strings(e) for e in exp]
+
+        return render_compact(strip_copy_strings(normalize_numbers(round_tripped)))
     except Exception:  # pylint: disable=W0703
         return lispress_str
 

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -71,8 +71,8 @@ def try_round_trip(lispress_str: str) -> str:
 
         def strip_copy_strings(exp: Lispress) -> "Lispress":
             if isinstance(exp, str):
-                if len(exp) > 2 and exp[0] == "\"" and exp[-1] == "\"":
-                    return "\"" + exp[1:-1].strip() + "\""
+                if len(exp) > 2 and exp[0] == '"' and exp[-1] == '"':
+                    return '"' + exp[1:-1].strip() + '"'
                 else:
                     return exp
             else:

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -152,3 +152,7 @@ def test_program_to_lispress_with_quotes_inside_string():
 def test_bare_values():
     assert try_round_trip("0") == "#(Number 0.0)"
     assert try_round_trip("#(Number 0)") == "#(Number 0.0)"
+
+
+def test_strip_copy_strings():
+    assert try_round_trip('#(String " Tom ")') == '#(String "Tom")'


### PR DESCRIPTION
Remove trailing spaces from copy strings in canonicalization.