### PR TITLE
Allow empty lists for backwards compatibility in JSON literals

### DIFF
--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -270,7 +270,9 @@ def op_to_lispress(op: Op) -> Lispress:
             assert isinstance(
                 underlying, (bool, str, int, float, list)
             ), f"Can't handle JSON dicts as value literals anymore, got {underlying}"
-            assert not (isinstance(underlying, list) and len(underlying) > 0), f"Can only handle empty list JSON value literals for backwards compatbility, but got {underlying}"
+            assert not (
+                isinstance(underlying, list) and len(underlying) > 0
+            ), f"Can only handle empty list JSON value literals for backwards compatibility, but got {underlying}"
             underlying_json_str = json.dumps(underlying)
             if schema in ("Number", "String", "Boolean"):
                 # Numbers and strings were typed in Calflow 1.0 (e.g. #(Number 1),

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -270,7 +270,7 @@ def op_to_lispress(op: Op) -> Lispress:
             assert isinstance(
                 underlying, (bool, str, int, float, list)
             ), f"Can't handle JSON dicts as value literals anymore, got {underlying}"
-            assert (not isinstance(underlying, list)) or len(underlying == 0), f"Can only handle empty list JSON value literals for backwards compatbility, but got {underlying}"
+            assert not (isinstance(underlying, list) and len(underlying == 0)), f"Can only handle empty list JSON value literals for backwards compatbility, but got {underlying}"
             underlying_json_str = json.dumps(underlying)
             if schema in ("Number", "String", "Boolean"):
                 # Numbers and strings were typed in Calflow 1.0 (e.g. #(Number 1),

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -270,7 +270,7 @@ def op_to_lispress(op: Op) -> Lispress:
             assert isinstance(
                 underlying, (bool, str, int, float, list)
             ), f"Can't handle JSON dicts as value literals anymore, got {underlying}"
-            assert not (isinstance(underlying, list) and len(underlying == 0)), f"Can only handle empty list JSON value literals for backwards compatbility, but got {underlying}"
+            assert not (isinstance(underlying, list) and len(underlying) > 0), f"Can only handle empty list JSON value literals for backwards compatbility, but got {underlying}"
             underlying_json_str = json.dumps(underlying)
             if schema in ("Number", "String", "Boolean"):
                 # Numbers and strings were typed in Calflow 1.0 (e.g. #(Number 1),

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -268,8 +268,9 @@ def op_to_lispress(op: Op) -> Lispress:
             return str(underlying) + "L"
         else:
             assert isinstance(
-                underlying, (bool, str, int, float)
+                underlying, (bool, str, int, float, list)
             ), f"Can't handle JSON dicts as value literals anymore, got {underlying}"
+            assert (not isinstance(underlying, list)) or len(underlying == 0), f"Can only handle empty list JSON value literals for backwards compatbility, but got {underlying}"
             underlying_json_str = json.dumps(underlying)
             if schema in ("Number", "String", "Boolean"):
                 # Numbers and strings were typed in Calflow 1.0 (e.g. #(Number 1),


### PR DESCRIPTION
I forgot that we have a special typed empty list literal. 