### PR TITLE
Update README and evaluate_onmt_predictions.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Follow the steps below to reproduce the results reported in the paper (Table 2).
 [the leaderboard](https://microsoft.github.io/task_oriented_dialogue_as_dataflow_synthesis/) to report your results for consistency.**
 If you use your own evaluation script, please pay attention to the notes in Step 2 and Step 7.
 
-1. Download the SMCalFlow dataset on [this page](https://microsoft.github.io/task_oriented_dialogue_as_dataflow_synthesis/).
+1. Download and unzip the SMCalFlow 1.0 dataset.
    ```bash
    dataflow_dialogues_dir="output/dataflow_dialogues"
    mkdir -p "${dataflow_dialogues_dir}"
@@ -62,6 +62,10 @@ If you use your own evaluation script, please pay attention to the notes in Step
    # The `PATH_TO_DATA_TGZ` is the path to the tgz file of the corresponding dataset.
    tar -xvzf PATH_TO_DATA_TGZ
    ```
+   * SMCalFlow 1.0 links
+     * [smcalflow.full.data.tgz](https://smresearchstorage.blob.core.windows.net/smcalflow-public/smcalflow.full.data.tgz)
+     * [smcalflow.inlined.data.tgz](https://smresearchstorage.blob.core.windows.net/smcalflow-public/smcalflow.inlined.data.tgz)
+   * SMCalFlow 2.0 can be found under the [datasets](./datasets) folder.
 2. Compute data statistics:
     ```bash
     dataflow_dialogues_stats_dir="output/dataflow_dialogues_stats"

--- a/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
+++ b/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
@@ -63,25 +63,13 @@ class OnmtPredictionReportDatum(PredictionReportDatum):
             return _PARSE_ERROR_LISPRESS
 
     @property
-    def is_correct(self) -> bool:
-        return (
-            self.gold == self.prediction
-            and self.program_execution_oracle.refer_are_correct
-        )
-
-    @property
     def is_correct_ignoring_refer(self) -> bool:
         return self.gold == self.prediction
 
     @property
-    def is_correct_leaderboard(self) -> bool:
-        """Returns true if the gold and the prediction match after canonicalization.
-
-        This is the metric used in the leaderboard, which would be slightly higher than the one reported in the TACL2020
-        paper, since the named arguments are sorted after canonicalization.
-        """
+    def is_correct(self) -> bool:
         return (
-            self.gold_canonical == self.prediction_canonical
+            self.is_correct_ignoring_refer
             and self.program_execution_oracle.refer_are_correct
         )
 
@@ -92,6 +80,18 @@ class OnmtPredictionReportDatum(PredictionReportDatum):
         Use this metric is you only care about the accuracy of the semantic parser, ignoring the execution of `refer`.
         """
         return self.gold_canonical == self.prediction_canonical
+
+    @property
+    def is_correct_leaderboard(self) -> bool:
+        """Returns true if the gold and the prediction match after canonicalization.
+
+        This is the metric used in the leaderboard, which would be slightly higher than the one reported in the TACL2020
+        paper, since the named arguments are sorted after canonicalization.
+        """
+        return (
+            self.is_correct_leaderboard_ignoring_refer
+            and self.program_execution_oracle.refer_are_correct
+        )
 
     def flatten_datum_id(self) -> Dict[str, Union[str, int]]:
         return {

--- a/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
+++ b/src/dataflow/onmt_helpers/create_onmt_prediction_report.py
@@ -70,6 +70,10 @@ class OnmtPredictionReportDatum(PredictionReportDatum):
         )
 
     @property
+    def is_correct_ignoring_refer(self) -> bool:
+        return self.gold == self.prediction
+
+    @property
     def is_correct_leaderboard(self) -> bool:
         """Returns true if the gold and the prediction match after canonicalization.
 
@@ -80,6 +84,14 @@ class OnmtPredictionReportDatum(PredictionReportDatum):
             self.gold_canonical == self.prediction_canonical
             and self.program_execution_oracle.refer_are_correct
         )
+
+    @property
+    def is_correct_leaderboard_ignoring_refer(self) -> bool:
+        """Returns true if the gold and the prediction match after canonicalization, ignoring the `refer_are_correct`.
+
+        Use this metric is you only care about the accuracy of the semantic parser, ignoring the execution of `refer`.
+        """
+        return self.gold_canonical == self.prediction_canonical
 
     def flatten_datum_id(self) -> Dict[str, Union[str, int]]:
         return {
@@ -99,7 +111,9 @@ class OnmtPredictionReportDatum(PredictionReportDatum):
                 "predictionCanonical": self.prediction_canonical,
                 "oracleResolveAreCorrect": self.program_execution_oracle.refer_are_correct,
                 "isCorrect": self.is_correct,
+                "isCorrectIgnoringRefer": self.is_correct_ignoring_refer,
                 "isCorrectLeaderboard": self.is_correct_leaderboard,
+                "isCorrectLeaderboardIgnoringRefer": self.is_correct_leaderboard_ignoring_refer,
             }
         )
         return flatten_datum_dict


### PR DESCRIPTION
1. Add links to `SMCalFlow 1.0` since now they are removed on the leaderboard webpage.
2. Report accuracy ignoring `refer_are_correct`, which is now also reported on the leaderboard.