### PR TITLE
Lambda lispress

### DIFF
--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -23,6 +23,8 @@ from dataflow.core.program_utils import is_idx_str as is_express_idx_str
 from dataflow.core.program_utils import (
     is_struct_op_schema,
     mk_call_op,
+    mk_lambda,
+    mk_lambda_arg,
     mk_struct_op,
     mk_type_name,
     mk_value_op,
@@ -368,6 +370,7 @@ def _program_to_unsugared_lispress(program: Program) -> Lispress:
     assert roots, "program must have at least one root"
 
     reentrant_ids: Dict[str, str] = {}
+    lambda_args: Dict[str, Sexp] = {}
     sexps_by_id: Dict[str, Sexp] = {}
     root_sexps: List[Sexp] = []
     let_bindings: List[Sexp] = []
@@ -392,11 +395,19 @@ def _program_to_unsugared_lispress(program: Program) -> Lispress:
             has_positional = any(k is None for k, _ in named_args)
             if not has_positional:
                 named_args = sorted(get_named_args(expression))  # sort alphabetically
-            for arg_name, arg_id in named_args:
+            for i, (arg_name, arg_id) in enumerate(named_args):
                 if arg_name is not None and not arg_name.startswith("arg"):
                     # name of named argument
                     curr += [_key_to_named_arg(arg_name)]
-                if arg_id in reentrant_ids:
+                if (
+                    arg_id in lambda_args
+                    and i == 0
+                    and isinstance(expression.op, CallLikeOp)
+                    and expression.op.name == DataflowFn.Lambda.value
+                ):
+                    # lambda arg binding
+                    curr += [[lambda_args[arg_id]]]
+                elif arg_id in reentrant_ids:
                     # reentrant steps are referred to by id
                     curr += [reentrant_ids[arg_id]]
                 elif arg_id in sexps_by_id:
@@ -411,10 +422,19 @@ def _program_to_unsugared_lispress(program: Program) -> Lispress:
             curr = [META_CHAR, type_name_to_lispress(expression.type), curr]
         # add it to results
         if idx in reentrancies:
-            # give reentrancies fresh ids as they are encountered
+            # give reentrancies (including lambda args) fresh ids as they are encountered
             new_id = _idx_to_var_str(len(reentrant_ids))
             reentrant_ids[idx] = new_id
-            let_bindings.extend([new_id, curr])
+            if (
+                isinstance(expression.op, CallLikeOp)
+                and expression.op.name == DataflowFn.LambdaArg.value
+            ):
+                # handle lambda args
+                curr = [META_CHAR, type_name_to_lispress(expression.type), new_id]
+                lambda_args[idx] = curr
+            else:
+                # handle normal reentrancies
+                let_bindings.extend([new_id, curr])
         elif idx in roots:
             root_sexps += [curr]
         else:
@@ -527,6 +547,32 @@ def unnest_line(
                 )
                 result_exprs.extend(exprs)
             return result_exprs, arg_idx, idx, var_id_bindings
+
+        elif hd == DataflowFn.Lambda.value:
+            # (lambda (^ArgType arg_name) body)
+            assert (
+                len(tl) == 2 and len(tl[0]) == 1
+            ), f"{DataflowFn.Lambda.value} binding must have a single arg, and a single body"
+            (arg,), body = tl
+            assert (
+                len(arg) == 3 and arg[0] == META_CHAR
+            ), f"{DataflowFn.Lambda.value} arg must have a type ascription, and a name"
+            _, arg_type, arg_name = arg
+            assert isinstance(arg_name, str)
+
+            arg_expr, arg_idx = mk_lambda_arg(mk_type_name(arg_type), idx)
+            result_exprs = [arg_expr]
+            # new arg binding is only in effect inside the body of the lambda
+            inner_var_id_bindings = dict(var_id_bindings)
+            inner_var_id_bindings[arg_name] = arg_idx
+            body_exprs, body_idx, idx, var_id_bindings = unnest_line(
+                body, arg_idx, inner_var_id_bindings
+            )
+            result_exprs.extend(body_exprs)
+            lambda_expr, idx = mk_lambda(arg_idx, body_idx, body_idx)
+            result_exprs.append(lambda_expr)
+            return result_exprs, idx, idx, var_id_bindings
+
         elif hd == SEQUENCE:
             # handle programs that have multiple statements sequenced together
             result_exprs = []

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -430,12 +430,12 @@ def _program_to_unsugared_lispress(program: Program) -> Lispress:
                 and expression.op.name == DataflowFn.LambdaArg.value
             ):
                 # handle lambda args
-                type_arg_lispress = (
+                type_arg_lispress: List[Sexp] = (
                     [type_name_to_lispress(a) for a in expression.type_args]
                     if expression.type_args is not None
                     else []
                 )
-                curr = [META_CHAR] + type_arg_lispress + [new_id]
+                curr = [META_CHAR, *type_arg_lispress, new_id]
                 lambda_args[idx] = curr
             else:
                 # handle normal reentrancies

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -522,7 +522,7 @@ def unnest_line(
         elif _is_idx_str(hd):
             # argId pointer
             # look up step index for var
-            assert hd in var_id_bindings
+            assert hd in var_id_bindings, s
             expr_id = var_id_bindings[hd]
             return [], expr_id, idx, var_id_bindings
         elif is_express_idx_str(hd):
@@ -596,8 +596,9 @@ def unnest_line(
             exprs, arg_idx, idx, var_id_bindings = unnest_line(
                 sexpr, idx=idx, var_id_bindings=var_id_bindings
             )
-            # Update is type declaration.
-            exprs[-1] = replace(exprs[-1], type=mk_type_name(type_declaration))
+            # Update its type declaration if it's more than just a variable reference.
+            if exprs:
+                exprs[-1] = replace(exprs[-1], type=mk_type_name(type_declaration))
             return exprs, arg_idx, idx, var_id_bindings
         elif hd == OpType.Value.value:
             assert (

--- a/src/dataflow/core/program_utils.py
+++ b/src/dataflow/core/program_utils.py
@@ -175,7 +175,6 @@ def mk_struct_op(
     schema: str, args: List[Tuple[Optional[str], Idx]], idx: Idx,
 ) -> Tuple[Expression, Idx]:
     new_idx = idx + 1
-    # args = dict(args)  # defensive copy
     base = next((v for k, v in args if k == NON_EMPTY_BASE), None)
     is_empty_base = base is None
     arg_names = [k for k, v in args]
@@ -195,13 +194,13 @@ def mk_struct_op(
 
 
 def mk_call_op(
-    name: str, args: List[Idx], tpe: Optional[TypeName] = None, idx: Idx = 0
+    name: str, args: List[Idx], type_args: Optional[List[TypeName]] = None, idx: Idx = 0
 ) -> Tuple[Expression, Idx]:
     new_idx = idx + 1
     flat_exp = Expression(
         id=idx_str(new_idx),
         op=CallLikeOp(name=name),
-        type=tpe,
+        type_args=type_args,
         arg_ids=[idx_str(v) for v in args],
     )
     return flat_exp, new_idx
@@ -222,7 +221,9 @@ def mk_value_op(value: Any, schema: str, idx: Idx) -> Tuple[Expression, Idx]:
 
 
 def mk_lambda_arg(type_name: TypeName, idx: Idx = 0) -> Tuple[Expression, Idx]:
-    return mk_call_op(name=DataflowFn.LambdaArg.value, tpe=type_name, args=[], idx=idx)
+    return mk_call_op(
+        name=DataflowFn.LambdaArg.value, type_args=[type_name], args=[], idx=idx
+    )
 
 
 def mk_lambda(arg_idx: Idx, body_idx: Idx, idx: Idx = 0) -> Tuple[Expression, Idx]:

--- a/src/dataflow/core/program_utils.py
+++ b/src/dataflow/core/program_utils.py
@@ -22,9 +22,6 @@ NEW = "new"
 # BuildStructOp special arg
 NON_EMPTY_BASE = "nonEmptyBase"
 
-# special 0-arg function that stands in for a lambda's argument
-LAMBDA_ARG = "lambda_arg"
-
 Idx = int
 
 

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -129,6 +129,42 @@ surface_strings = [
       "veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeerylong")
     #(PersonName "short")))
 """,
+    # nested lambdas
+    """
+(action
+  (Inform
+    (^(Navigation) Find
+      :focus (Some
+        (Constraint.apply
+          (lambda
+            (^Navigation x0)
+            (allows
+              (Constraint.apply
+                (lambda
+                  (^AppleDuration x1)
+                  (allows (?= 10) (AppleDuration.minutes x1))))
+              (Navigation.travelTime x0))))))))
+""",
+    """
+(action
+  (Prompt
+    (^(Message) Create
+      :object (Some
+        (Constraint.apply
+          (lambda
+            (^Message x0)
+            (allows
+              (Constraint.apply
+                (lambda
+                  (^Contact x1)
+                  (allows
+                    (Constraint.apply
+                      (lambda
+                        (^Person x2)
+                        (allows (^(String) always) (Person.nameHint x2))))
+                    (Contact.person x1))))
+              (Message.recipients x0))))))))
+""",
 ]
 
 

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -287,5 +287,9 @@ def test_type_args_in_program():
 
 
 def test_fully_typed_reference():
+    # This is a regression test, formerly an Exception was thrown.
     s = "(lambda (^Unit x0) ^Unit x0)"
+    # The second type ascription is not retained because x0 is represented by
+    # a single node in a Program, and so can't have two separate type
+    # ascriptions.
     assert round_trip_through_program(s) == "(lambda (^Unit x0) x0)"

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -165,6 +165,17 @@ surface_strings = [
                     (Contact.person x1))))
               (Message.recipients x0))))))))
 """,
+    # nested lambda type-arg
+    """
+(plan
+  (revise
+    (^(Unit) Path.apply "Create")
+    (^((Constraint Person)) Path.apply
+      "object.recipients.person")
+    (lambda
+      (^(Constraint Person) x0)
+      (& x0 (Person.nameHint_? (?= "Payne"))))))
+""",
 ]
 
 

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -180,19 +180,22 @@ def test_surface_to_sexp_round_trips():
         assert round_tripped_surface_string == surface_string
 
 
+def round_trip_through_program(s):
+    sexp = parse_lispress(s)
+    program, _ = lispress_to_program(sexp, 0)
+    round_tripped_sexp = program_to_lispress(program)
+    return render_pretty(round_tripped_sexp, max_width=60)
+
+
 def test_surface_to_program_round_trips():
     """
     Goes all the way to `Program` and so is stricter
     than `test_surface_to_sexp_round_trips`.
     """
     for surface_string in surface_strings:
-        surface_string = surface_string.strip()
-        sexp = parse_lispress(surface_string)
-        program, _ = lispress_to_program(sexp, 0)
-        round_tripped_sexp = program_to_lispress(program)
-        assert round_tripped_sexp == sexp
-        round_tripped_surface_string = render_pretty(round_tripped_sexp, max_width=60)
-        assert round_tripped_surface_string == surface_string
+        s = surface_string.strip()
+        round_tripped_surface_string = round_trip_through_program(s)
+        assert round_tripped_surface_string == s
 
 
 def test_program_to_lispress_with_quotes_inside_string():
@@ -270,3 +273,8 @@ def test_type_args_in_program():
     assert len(program.expressions) == 1
     assert program.expressions[0].type_args == [TypeName("PleasantryCalendar", ())]
     assert program.expressions[0].type is None
+
+
+def test_fully_typed_reference():
+    s = "(lambda (^Unit x0) ^Unit x0)"
+    assert round_trip_through_program(s) == "(lambda (^Unit x0) x0)"


### PR DESCRIPTION
updates `lispress_to_program` and `program_to_lispress` to handle the lambda syntax that's used in TreeDST.
e.g.:

```clojure
(action
  (Inform
    (^(Navigation) Find
      :focus (Some
        (Constraint.apply
          (lambda
            (^Navigation x0)
            (allows
              (Constraint.apply
                (lambda
                  (^AppleDuration x1)
                  (allows (?= 10) (AppleDuration.minutes x1))))
              (Navigation.travelTime x0))))))))
```