### PR TITLE
bugfix for lambdas where their arg is never referenced

### DIFF
--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -421,8 +421,11 @@ def _program_to_unsugared_lispress(program: Program) -> Lispress:
         if expression.type:
             curr = [META_CHAR, type_name_to_lispress(expression.type), curr]
         # add it to results
-        if idx in reentrancies:
-            # give reentrancies (including lambda args) fresh ids as they are encountered
+        if idx in reentrancies or (
+            isinstance(expression.op, CallLikeOp)
+            and expression.op.name == DataflowFn.LambdaArg.value
+        ):
+            # give reentrancies and lambda args fresh ids as they are encountered
             new_id = _idx_to_var_str(len(reentrant_ids))
             reentrant_ids[idx] = new_id
             if (

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -176,6 +176,17 @@ surface_strings = [
       (^(Constraint Person) x0)
       (& x0 (Person.nameHint_? (?= "Payne"))))))
 """,
+    # lambda arg that is never referenced
+    """
+(plan
+  (revise
+    (^(Unit) Path.apply "Create")
+    (^((Option (Constraint ConfirmStatus))) Path.apply
+      "confirmation")
+    (lambda
+      (^(Option (Constraint ConfirmStatus)) x0)
+      (Some (?= (ConfirmStatus.Accepted))))))
+""",
 ]
 
 


### PR DESCRIPTION
code wrongly assumed that all lambda args were reentrancies