### PR TITLE
fix typo in README-SEMANTICS.md

### DIFF
--- a/README-SEMANTICS.md
+++ b/README-SEMANTICS.md
@@ -104,7 +104,7 @@ The user can query events in the calendar. If the user says
   (Event.location 
     (singleton 
       (QueryEventResponse.results 
-        (FindEventWrapperWithDefaults (Event.subject_? (?~= "cat sitting")))))))
+        (FindEventWrapperWithDefaults (Event.subject_? (?~= "avocado festival")))))))
 ```
 This program builds an `Event` constraint requiring the event's
 subject to fuzzily match the string "avocado festival" (the `?~=`


### PR DESCRIPTION
Hi all, I noticed a small typo while reading this document. Hope I've understood things correctly, and thanks for taking the time to release these documentation pieces!