### PR TITLE
Canonicalize `let` bindings

### DIFF
--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -655,7 +655,7 @@ def unnest_line(
 def _unsugared_lispress_to_program(fs: Lispress, idx: Idx) -> Tuple[Program, Idx]:
     if isinstance(fs, list) and len(fs) == 0:
         # special-case the empty program
-        exprs = []
+        exprs: List[Expression] = []
     else:
         exprs, _, idx, _ = unnest_line(fs, idx, {})
     return Program(expressions=exprs), idx
@@ -681,14 +681,14 @@ def _canonicalize_program(program: Program) -> Program:
     exprs = program.expressions_by_id
     if len(exprs) == 0:
         return program
-    roots, reentrancies = roots_and_reentrancies(program)
+    roots, _ = roots_and_reentrancies(program)
     if len(roots) > 1:
         # add a `do` expression so there is a single root
         new_id = max([-1] + [unwrap_idx_str(i) for i in exprs.keys()]) + 1
         new_idx = idx_str(new_id)
         do = Expression(id=new_idx, op=CallLikeOp(DataflowFn.Do.value), arg_ids=roots)
         exprs[new_idx] = do
-        roots = [do]
+        roots = [new_idx]
     assert len(roots) == 1
     (root,) = roots
 

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -591,16 +591,6 @@ def unnest_line(
             result_exprs.append(lambda_expr)
             return result_exprs, idx, idx, var_id_bindings
 
-        elif hd == SEQUENCE:
-            # handle programs that have multiple statements sequenced together
-            result_exprs = []
-            arg_idx = idx  # in case `tl` is empty
-            for statement in tl:
-                exprs, arg_idx, idx, var_id_bindings = unnest_line(
-                    statement, idx, var_id_bindings
-                )
-                result_exprs.extend(exprs)
-            return result_exprs, arg_idx, idx, var_id_bindings
         elif hd == META_CHAR:
             # type ascriptions look like (^T Expr), e.g. (^Number (+ 1 2))
             # would be (1 + 2): Number in Scala.
@@ -664,15 +654,12 @@ def unnest_line(
 
 
 def _unsugared_lispress_to_program(fs: Lispress, idx: Idx) -> Tuple[Program, Idx]:
-    arg_id_map: Dict[str, int] = {}
-    expressions = []
     if isinstance(fs, list) and len(fs) == 0:
         # special-case the empty program
-        return Program(expressions=[]), idx
+        exprs = []
     else:
-        exprs, _, idx, arg_id_map = unnest_line(fs, idx, arg_id_map)
-        expressions.extend(exprs)
-    return Program(expressions=expressions), idx
+        exprs, _, idx, _ = unnest_line(fs, idx, {})
+    return Program(expressions=exprs), idx
 
 
 def lispress_to_type_name(e: Lispress) -> TypeName:

--- a/src/dataflow/core/lispress.py
+++ b/src/dataflow/core/lispress.py
@@ -4,7 +4,7 @@ import json
 import re
 from dataclasses import replace
 from json import JSONDecodeError, loads
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 from more_itertools import chunked
 
@@ -18,7 +18,7 @@ from dataflow.core.program import (
     ValueOp,
     roots_and_reentrancies,
 )
-from dataflow.core.program_utils import DataflowFn, Idx, OpType, get_named_args
+from dataflow.core.program_utils import DataflowFn, Idx, OpType, get_named_args, idx_str
 from dataflow.core.program_utils import is_idx_str as is_express_idx_str
 from dataflow.core.program_utils import (
     is_struct_op_schema,
@@ -38,9 +38,7 @@ EXTERNAL_LABEL = "ExternalReference"
 NUM_INDENTATION_SPACES = 2
 # keyword for introducing variable bindings
 LET = "let"
-# keyword for sequencing programs that have multiple statements
-SEQUENCE = "do"
-SEQUENCE_SEXP: List[Sexp] = [SEQUENCE]  # to help out mypy
+DO_SEXP: List[Sexp] = [DataflowFn.Do.value]  # to help out mypy
 # variables will be named `x0`, `x1`, etc., in the order they are introduced.
 VAR_PREFIX = "x"
 # named args are given like `(fn :name1 arg1 :name2 arg2 ...)`
@@ -61,12 +59,12 @@ def try_round_trip(lispress_str: str) -> str:
     If it is not valid, returns the original string unmodified.
     """
     try:
-        return _try_round_trip(lispress_str)
+        return _round_trip(lispress_str)
     except Exception:  # pylint: disable=W0703
         return lispress_str
 
 
-def _try_round_trip(lispress_str: str) -> str:
+def _round_trip(lispress_str: str) -> str:
     # round-trip to canonicalize
     lispress = parse_lispress(lispress_str)
     program, _ = lispress_to_program(lispress, 0)
@@ -100,7 +98,8 @@ def strip_copy_strings(exp: Lispress) -> "Lispress":
 
 def program_to_lispress(program: Program) -> Lispress:
     """ Converts a Program to Lispress. """
-    unsugared = _program_to_unsugared_lispress(program)
+    canonicalized = _canonicalize_program(program)
+    unsugared = _program_to_unsugared_lispress(canonicalized)
     sugared_gets = _sugar_gets(unsugared)
     return sugared_gets
 
@@ -455,7 +454,7 @@ def _program_to_unsugared_lispress(program: Program) -> Lispress:
         if len(root_sexps) == 0
         else root_sexps[0]
         if len(root_sexps) == 1
-        else SEQUENCE_SEXP + root_sexps
+        else DO_SEXP + root_sexps
     )
     # `let` bindings go at the top-level
     return [LET, let_bindings, result] if len(let_bindings) > 0 else result
@@ -672,3 +671,36 @@ def lispress_to_type_name(e: Lispress) -> TypeName:
         return TypeName(constructor, tuple([lispress_to_type_name(a) for a in args]))
     else:
         raise ValueError(f"unexpected lispress {e}")
+
+
+def _canonicalize_program(program: Program) -> Program:
+    """
+    Adds a top-level `do` expression if there are multiple roots,
+    and orders expressions left-to-right bottom-up.
+    """
+    exprs = program.expressions_by_id
+    if len(exprs) == 0:
+        return program
+    roots, reentrancies = roots_and_reentrancies(program)
+    if len(roots) > 1:
+        # add a `do` expression so there is a single root
+        new_id = max([-1] + [unwrap_idx_str(i) for i in exprs.keys()]) + 1
+        new_idx = idx_str(new_id)
+        do = Expression(id=new_idx, op=CallLikeOp(DataflowFn.Do.value), arg_ids=roots)
+        exprs[new_idx] = do
+        roots = [do]
+    assert len(roots) == 1
+    (root,) = roots
+
+    seen: Set[str] = set()
+
+    def traversal(i: str) -> Iterator[Expression]:
+        """Left-to-right bottom-up"""
+        if i not in seen:
+            seen.add(i)
+            e = exprs[i]
+            for c in e.arg_ids:
+                yield from traversal(c)
+            yield e
+
+    return Program(expressions=list(traversal(root)))

--- a/src/dataflow/core/program.py
+++ b/src/dataflow/core/program.py
@@ -65,11 +65,16 @@ class Program:
         return {expression.id: expression for expression in self.expressions}
 
 
-def roots_and_reentrancies(program: Program) -> Tuple[Set[str], Set[str]]:
-    ids = {e.id for e in program.expressions}
+def roots_and_reentrancies(program: Program) -> Tuple[List[str], Set[str]]:
+    """
+    Returns ids of roots (expressions that never appear as arguments) and
+    reentrancies (expressions that appear more than once as arguments).
+    Now that `do` expressions get their own nodes, there should be exactly
+    one root.
+    """
     arg_counts = Counter(a for e in program.expressions for a in e.arg_ids)
-    roots = ids.difference(arg_counts)  # ids that are never used as args
-    reentrancies = {
-        i for i, c in arg_counts.items() if c >= 2
-    }  # args that are used multiple times as args
+    # ids that are never used as args
+    roots = [e.id for e in program.expressions if e.id not in arg_counts]
+    # args that are used multiple times as args
+    reentrancies = {i for i, c in arg_counts.items() if c >= 2}
     return roots, reentrancies

--- a/src/dataflow/core/program_utils.py
+++ b/src/dataflow/core/program_utils.py
@@ -36,6 +36,7 @@ class OpType(Enum):
 class DataflowFn(Enum):
     """Special Dataflow functions"""
 
+    Do = "do"  # keyword for sequencing programs that have multiple statements
     Find = "find"  # search
     Abandon = "abandon"
     Revise = "ReviseConstraint"
@@ -109,7 +110,7 @@ def mk_salience(tpe: str, idx: Idx) -> Tuple[List[Expression], Idx]:
 
 def mk_salient_action(idx: Idx) -> Tuple[List[Expression], Idx]:
     """ (roleConstraint #(Path "output")) """
-    path_expr, path_idx = mk_value_op(schema="Path", value="output", idx=idx,)
+    path_expr, path_idx = mk_value_op(schema="Path", value="output", idx=idx)
     intension_expr, intension_idx = mk_call_op(
         name=DataflowFn.RoleConstraint.value, args=[path_idx], idx=path_idx,
     )
@@ -194,7 +195,10 @@ def mk_struct_op(
 
 
 def mk_call_op(
-    name: str, args: List[Idx], type_args: Optional[List[TypeName]] = None, idx: Idx = 0
+    name: str,
+    args: List[Idx],
+    type_args: Optional[List[TypeName]] = None,
+    idx: Idx = 0,
 ) -> Tuple[Expression, Idx]:
     new_idx = idx + 1
     flat_exp = Expression(

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -329,3 +329,9 @@ def test_canonicalize_program():
     assert do.op.name == DataflowFn.Do.value
     assert do.arg_ids == [e.id for e in p.expressions]
     assert render_pretty(program_to_lispress(p)) == '(do "" 1L)'
+
+
+def test_let_bindings_canonicalized():
+    a = """(let (x0 (singleton (QueryEventResponse.results (FindEventWrapperWithDefaults (& (Event.subject_? (?~= "lunch")) (Event.attendees_? (AttendeeListHasRecipientConstraint (RecipientWithNameLike (^(Recipient) EmptyStructConstraint) (PersonName.apply "Jeff")))))))) x1 (singleton (QueryEventResponse.results (FindEventWrapperWithDefaults (Event.subject_? (?~= "haircut appointment")))))) (Yield (CreateCommitEventWrapper (CreatePreflightEventWrapper (& (Event.start_? (DateTimeAndConstraintBetweenEvents x0 x1)) (Event.end_? (DateTimeAndConstraintBetweenEvents x0 x1)))))))"""
+    b = """(let (x0 (singleton (QueryEventResponse.results (FindEventWrapperWithDefaults (Event.subject_? (?~= "haircut appointment"))))) x1 (singleton (QueryEventResponse.results (FindEventWrapperWithDefaults (& (Event.subject_? (?~= "lunch")) (Event.attendees_? (AttendeeListHasRecipientConstraint (RecipientWithNameLike (^(Recipient) EmptyStructConstraint) (PersonName.apply "Jeff"))))))))) (Yield (CreateCommitEventWrapper (CreatePreflightEventWrapper (& (Event.start_? (DateTimeAndConstraintBetweenEvents x1 x0)) (Event.end_? (DateTimeAndConstraintBetweenEvents x1 x0)))))))"""
+    assert _round_trip(a) == _round_trip(b)

--- a/tests/test_dataflow/core/test_lispress.py
+++ b/tests/test_dataflow/core/test_lispress.py
@@ -304,3 +304,14 @@ def test_fully_typed_reference():
     # a single node in a Program, and so can't have two separate type
     # ascriptions.
     assert round_trip_through_program(s) == "(lambda (^Unit x0) x0)"
+
+
+def test_let_bindings_are_canonicalized():
+    """
+    Let bindings should be topologically sorted,
+    with ties broken by alphabetically sorting their bodies.
+    Also tests that `do` ordering (including multiple mentions) is maintained.
+    """
+    s = '(let (x0 1 x1 "") (do x0 x1 x1 x0))'
+    # formerly would return `'(do 1 "")'`
+    assert round_trip_through_program(s) == '(let (x0 "" x1 1) (do x1 x0 x0 x1))'


### PR DESCRIPTION
Also gives `do` its own `Expression` in a `Program`, so that order and multiplicity is not lost.
These changes make comparing canonicalized Lispress with exact match more robust.